### PR TITLE
add login and create account functionality to frontend and improve backend calls

### DIFF
--- a/frontend/src/app/api/api.ts
+++ b/frontend/src/app/api/api.ts
@@ -1,15 +1,15 @@
 "use server";
 
 import { MatchingGames, PlayerSummary, AchievementComparisonData } from "../definitions/types";
-import { baseURL } from "../definitions/urls";
+import { apiURL } from "../definitions/urls";
 
 export async function getPlayerSummaries(steamIDs: string): Promise<PlayerSummary[]> {
-	if (!baseURL) {
+	if (!apiURL) {
 		console.log("Backend base URL not set up in environment variables")
 		return [];
 	}
 
-	const url = new URL("player-summaries", baseURL);
+	const url = new URL("player-summaries", apiURL);
 	url.searchParams.set("steamIDs", steamIDs);
 
 	let summaries: PlayerSummary[] = [];
@@ -25,20 +25,20 @@ export async function getPlayerSummaries(steamIDs: string): Promise<PlayerSummar
 		const json = await resp.json();
 
 		summaries = json.players
-	} catch (e) {
-		console.log(`Failed to get player summaries: ${e}`);
+	} catch (err) {
+		console.log(`Failed to get player summaries: ${err}`);
 	}
 
 	return summaries;
 }
 
 export async function getFriendsList(steamID: string): Promise<PlayerSummary[]> {
-	if (!baseURL) {
+	if (!apiURL) {
 		console.log("Backend base URL not set up in environment variables")
 		return [];
 	}
 
-	const url = new URL("friends", baseURL);
+	const url = new URL("friends", apiURL);
 	url.searchParams.set("steamID", steamID)
 
 	let friendsList: PlayerSummary[] = [];
@@ -55,20 +55,20 @@ export async function getFriendsList(steamID: string): Promise<PlayerSummary[]> 
 
 		friendsList = json.players;
 
-	} catch (e) {
-		console.log(`Failed to get friends list: ${e}`);
+	} catch (err) {
+		console.log(`Failed to get friends list: ${err}`);
 	}
 
 	return friendsList
 }
 
 export async function getMatchingGames(steamID: string): Promise<MatchingGames[]> {
-    if (!baseURL) {
+    if (!apiURL) {
         console.log("Backend base URL not set up in environment variable")
         return [];
     }
 
-    const url = new URL("friends/matchGames", baseURL);
+    const url = new URL("friends/matchGames", apiURL);
     url.searchParams.set("steamID", steamID);
     url.searchParams.set("listGames", "true");
 
@@ -87,8 +87,8 @@ export async function getMatchingGames(steamID: string): Promise<MatchingGames[]
         if (json.ranking != undefined) {
             matchedGamesRanking = json.ranking;
         }
-    } catch (e) {
-        console.log(`Failed to get matched games ranking: ${e}`);
+    } catch (err) {
+        console.log(`Failed to get matched games ranking: ${err}`);
     }
 
     return matchedGamesRanking
@@ -99,12 +99,12 @@ export async function getAchievementComparison(
   friendID: string,
   appID: number
 ): Promise<AchievementComparisonData | null> {
-  if (!baseURL) {
+  if (!apiURL) {
     console.log("Backend base URL not set up in environment variables");
     return null;
   }
 
-  const url = new URL("compare-achievements", baseURL);
+  const url = new URL("compare-achievements", apiURL);
   url.searchParams.set("userID", userID);
   url.searchParams.set("friendID", friendID);
   url.searchParams.set("appID", appID.toString());
@@ -121,8 +121,8 @@ export async function getAchievementComparison(
     // This should match the AchievementComparisonData interface
     const data: AchievementComparisonData = await resp.json();
     return data;
-  } catch (e) {
-    console.log(`Failed to get achievement comparison: ${e}`);
+  } catch (err) {
+    console.log(`Failed to get achievement comparison: ${err}`);
     return null;
   }
 }

--- a/frontend/src/app/api/auth.ts
+++ b/frontend/src/app/api/auth.ts
@@ -1,0 +1,48 @@
+import { backendURL } from "../definitions/urls";
+
+export async function createAccount(email: string, password: string, steamID: string) {
+  if (!backendURL) {
+    throw new Error("Backend base URL not set up in environment variables");
+  }
+  const url = new URL("users/create", backendURL);
+
+  try {
+    const resp = await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: email, password, steam_id: steamID }),
+    });
+
+    if (resp.status >= 400) {
+      const data = await resp.json();
+      throw new Error(data.error || `Failed with status ${resp.status}`);
+    }
+    return await resp.json();
+  } catch (err) {
+    throw err;
+  }
+}
+
+export async function login(email: string, password: string) {
+  if (!backendURL) {
+    throw new Error("Backend base URL not set up in environment variables");
+  }
+  const url = new URL("users/login", backendURL);
+
+  try {
+    const resp = await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: email, password }),
+    //   credentials: "include", (commenting this out for now, but will be used in prod for HttpOnly cookies)
+    });
+
+    if (resp.status >= 400) {
+      const data = await resp.json();
+      throw new Error(data.error || `Failed with status ${resp.status}`);
+    }
+    return await resp.json();
+  } catch (err) {
+    throw err;
+  }
+}

--- a/frontend/src/app/components/AuthModal/AuthModal.tsx
+++ b/frontend/src/app/components/AuthModal/AuthModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import styles from "../../page.module.css"
+import { createAccount, login } from "../../api/auth";
+
+interface AuthModalProps {
+  type: "signup" | "login";
+  onClose: () => void;
+  setLoading: (val: boolean) => void;
+}
+
+const AuthModal: React.FC<AuthModalProps> = ({ type, onClose, setLoading }) => {
+  const [fields, setFields] = useState({ username: "", password: "", steam_id: "" });
+  const [error, setError] = useState("");
+  const router = useRouter();
+
+  const handleChange = (err: React.ChangeEvent<HTMLInputElement>) =>
+  setFields({ ...fields, [err.target.name]: err.target.value });
+
+  const handleSubmit = async (err: React.FormEvent) => {
+  err.preventDefault();
+  setError("");
+  setLoading(true);
+  try {
+      let data;
+      if (type === "signup") {
+        data = await createAccount(fields.username, fields.password, fields.steam_id);
+      } else {
+        data = await login(fields.username, fields.password);
+      }
+
+      const steamID = data.user?.steam_id;
+      if (steamID) {
+        onClose();
+        router.push(`/${steamID}`);
+      } else {
+        setError("Missing Steam ID in server response.");
+      }
+  } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("An unknown error occurred");
+      }
+    }
+  };
+
+  return (
+    <div className={styles.modalOverlay}>
+      <div className={styles.modalBox}>
+        <button className={styles.closeBtn} onClick={onClose}>&times;</button>
+        <div className={styles.modalTitle}>{type === "signup" ? "Create Account" : "Log In"}</div>
+        <form onSubmit={handleSubmit}>
+          <input
+            className={styles.modalInput}
+            type="email"
+            name="username"
+            required
+            placeholder="Email"
+            value={fields.username}
+            onChange={handleChange}
+            autoComplete="username"
+          />
+          <input
+            className={styles.modalInput}
+            type="password"
+            name="password"
+            required
+            placeholder="Password"
+            value={fields.password}
+            onChange={handleChange}
+            autoComplete={type === "signup" ? "new-password" : "current-password"}
+          />
+          {type === "signup" && (
+            <input
+              className={styles.modalInput}
+              type="text"
+              name="steam_id"
+              required
+              placeholder="Steam ID"
+              value={fields.steam_id}
+              onChange={handleChange}
+            />
+          )}
+          {error && <div className={styles.modalError}>{error}</div>}
+            <button className={styles.modalSubmit} type="submit">
+            {type === "signup" ? "Create Account" : "Log In"}
+            </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AuthModal;

--- a/frontend/src/app/definitions/urls.ts
+++ b/frontend/src/app/definitions/urls.ts
@@ -1,4 +1,7 @@
-export const baseURL = process.env.NODE_ENV === "production"
+export const apiURL = process.env.NODE_ENV === "production"
 	? process.env.NEXT_PUBLIC_API_URL
 	: "http://localhost:8080/api/steam/";
-	
+
+export const backendURL = process.env.NODE_ENV === "production"
+	? process.env.NEXT_BACKEND_URL
+	: "http://localhost:8080/v1/"

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -83,3 +83,157 @@
   transform: translateY(-1px) scale(1.03);
   opacity: 1;
 }
+
+.modalOverlay {
+  position: fixed;
+  z-index: 999;
+  left: 0; top: 0; right: 0; bottom: 0;
+  background: rgba(10, 18, 26, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modalBox {
+  background: var(--dark-card, #23272e);
+  color: #e5e9f1;
+  border-radius: 20px;
+  padding: 32px 36px;
+  min-width: 340px;
+  box-shadow: 0 6px 40px 0 rgba(0,0,0,0.40);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-size: 1.3rem;
+  color: #7b8fa6;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.closeBtn:hover {
+  color: #fff;
+}
+
+.modalTitle {
+  font-weight: bold;
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+}
+
+.modalInput {
+  width: 100%;
+  padding: 10px 14px;
+  background: #22282f;
+  border: 1.5px solid #a4b1be;
+  border-radius: 10px;
+  color: #e5e9f1;
+  font-size: 1rem;
+  margin-bottom: 14px;
+  outline: none;
+  transition: border 0.2s;
+}
+
+.modalInput,
+.modalSubmit {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 14px;
+  font-size: 1rem;
+}
+
+.modalSubmit {
+  background: linear-gradient(90deg, var(--accent-light-rgb) 20%, var(--steam-light-blue) 80%);
+  color: #10181e;
+  border-radius: 12px;
+  font-weight: 700;
+  box-shadow: 0 2px 8px 0 #10181e33;
+  border: none;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background 0.2s;
+  min-height: 44px;
+}
+
+.modalSubmit:hover {
+  background: linear-gradient(90deg, var(--accent-200) 20%, var(--steam-light-blue) 80%);
+  color: #10181e;
+  transform: translateY(-1px) scale(1.03);
+  opacity: 1;
+}
+
+.modalError {
+  color: #ff5c5c;
+  font-size: 1rem;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.formButton {
+  background: linear-gradient(90deg, var(--accent-light-rgb) 20%, var(--steam-light-blue) 80%);
+  color: #10181e;
+  border-radius: 12px;
+  font-weight: 700;
+  padding: 8px 20px;
+  box-shadow: 0 2px 8px 0 #10181e33;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-size: 1rem;
+  margin-left: 12px;
+}
+
+.formButton:first-child {
+  margin-left: 0;
+}
+
+.formButton:hover {
+  background: linear-gradient(90deg, var(--accent-200) 20%, var(--steam-light-blue) 80%);
+  color: #10181e;
+  transform: translateY(-1px) scale(1.03);
+  opacity: 1;
+}
+
+.loadingOverlay {
+  position: fixed;
+  z-index: 1200;
+  left: 0; top: 0; right: 0; bottom: 0;
+  background: rgba(10, 18, 26, 0.75);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: all;
+}
+
+.loadingBox {
+  background: var(--dark-card, #23272e);
+  color: #e5e9f1;
+  border-radius: 16px;
+  padding: 40px 52px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  box-shadow: 0 8px 40px 0 rgba(0,0,0,0.55);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  opacity: 0.98;
+}
+@keyframes loadingSpin {
+  100% { transform: rotate(360deg); }
+}
+.loadingSpinner {
+  width: 28px;
+  height: 28px;
+  border: 4px solid #3a4556;
+  border-top: 4px solid var(--steam-light-blue, #67c1f5);
+  border-radius: 50%;
+  animation: loadingSpin 0.9s linear infinite;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,9 +3,13 @@
 import { useState } from "react";
 import styles from "./page.module.css";
 import { useRouter } from "next/navigation";
+import AuthModal from "./components/AuthModal/AuthModal";
 
 export default function Home() {
   const [userID, setUserID] = useState<string>("");
+  const [showLogin, setShowLogin] = useState(false);
+  const [showSignup, setShowSignup] = useState(false);
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   // Allows for an optional Steam Community profile URL that contains the Steam ID to be submitted instead
@@ -15,7 +19,7 @@ export default function Home() {
     if (match !== null) {
       destination = match[1];
     }
-
+    setLoading(true);
     router.push(`/${destination}`);
   }
 
@@ -23,7 +27,28 @@ export default function Home() {
     <>
       <header className={styles.header}>
         <h1 className={styles.logoTitle}>Steam Lens</h1>
+        <div>
+          <button className={styles.formButton} onClick={() => setShowLogin(true)}>Log In</button>
+          <button className={styles.formButton} onClick={() => setShowSignup(true)} style={{marginLeft: 12}}>Create Account</button>
+        </div>
       </header>
+
+      {showLogin && (
+        <AuthModal type="login" onClose={() => setShowLogin(false)} setLoading={setLoading} />
+      )}
+      {showSignup && (
+        <AuthModal type="signup" onClose={() => setShowSignup(false)} setLoading={setLoading} />
+      )}
+
+      {loading && (
+        <div className={styles.loadingOverlay}>
+          <div className={styles.loadingBox}>
+            <div className={styles.loadingSpinner}></div>
+            Loading stats&hellip;
+          </div>
+        </div>
+      )}
+
       <main className={styles.main}>
         <div className={styles.section}>
           <div className={styles.form}>
@@ -48,11 +73,12 @@ export default function Home() {
             Enter a 17 digit numeric Steam ID of your own or a user you want to run comparisons on.
           </p>
           <p>
-            Once entered, clicking submit will redirect you over to the main dashboard where you&apos;ll be able to compare games and achievements.
+            Once entered, clicking submit will redirect you over to the main dashboard where you&apos;ll be able to compare games and achievements 
+            (there is a load time depending on how many friends the user has, see under &quot;limitations&quot; at the bottom of this page.).
           </p>
           <p>
             Note, if the user or a friend has their profile privated in any way then that can prevent data from the API to return for that account.
-            If you notice rankings, games, achievement counts, etc. aren&apos;t loading for a specific person then apart from the daily API limit being reached that would 
+            If you notice data isn&apos;t loading for a specific person then apart from Steam&apos;s API limits being reached that would 
             the reason for data not loading.
           </p>
         </div>
@@ -67,11 +93,16 @@ export default function Home() {
           <h2 className={styles.h2}>Limitations</h2>
           <p>
             This website works only because of Valve&apos;s Steam API that is useable for anyone with a Steam account that requests an API key.
-            They have a 100,000 daily API call limit. If you notice errors being thrown or data not loading, then it is likely due to that limit being reached
-            since user/friend data, game data, and achievement data are all gotten from Steam&apos;s endpoints.
+            They have a 100,000 daily API call limit and I have also observed a short-term limit if you make too many API calls at once in a short period of time. 
+            If you notice errors being thrown or data not loading, then it is likely due to that limit being reached since user/friend data, game data, and achievement data are all gotten from Steam&apos;s endpoints.
           </p>
           <p>
             I have added backend caching of the data returned from Steam&apos;s endpoints to reduce API calls as much as possible to make it unlikely this daily limit is reached.
+          </p>
+          <p>
+            On top of this, I have also added a wait time for stats to load depending on how many friends a user has. For example if a user has over 100 friends
+            then it will take 10 seconds to load bare minimum, if more than 50 friends but less than 100 it will take 5 seconds to load bare minimum, and if less than 50 friends it will take 2 seconds to load bare minimum. 
+            This is to help prevent &quot;too many request&quot; errors from Steam&apos;s API.
           </p>
         </div>
       </main >

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -3,6 +3,9 @@ package api
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -77,6 +80,13 @@ func (apicfg *ApiConfig) GetPlayerSummaries(steamIDs []string) (Summaries, error
 	}
 	defer resp.Body.Close()
 
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		testBody, _ := io.ReadAll(resp.Body)
+		fmt.Printf("Unexpected response from Steam API: %s\n", testBody)
+		return Summaries{}, errors.New("steam API returned non-JSON response")
+	}
+
 	decoder := json.NewDecoder(resp.Body)
 
 	body := SummariesResponse{}
@@ -139,6 +149,13 @@ func (apicfg *ApiConfig) GetOwnedGames(steamID string) (OwnedGames, error) {
 	}
 	defer resp.Body.Close()
 
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		testBody, _ := io.ReadAll(resp.Body)
+		fmt.Printf("Unexpected response from Steam API: %s\n", testBody)
+		return OwnedGames{}, errors.New("steam API returned non-JSON response")
+	}
+
 	decoder := json.NewDecoder(resp.Body)
 
 	body := OwnedGamesResponse{}
@@ -195,6 +212,13 @@ func (apicfg *ApiConfig) GetFriendList(steamID string) (FriendList, error) {
 		return FriendList{}, err
 	}
 	defer resp.Body.Close()
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		testBody, _ := io.ReadAll(resp.Body)
+		fmt.Printf("Unexpected response from Steam API: %s\n", testBody)
+		return FriendList{}, errors.New("steam API returned non-JSON response")
+	}
 
 	decoder := json.NewDecoder(resp.Body)
 
@@ -260,6 +284,13 @@ func (apicfg *ApiConfig) GetPlayerAchievements(steamID, appID string) (Converted
 		return ConvertedPlayerAchievements{}, err
 	}
 	defer resp.Body.Close()
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		testBody, _ := io.ReadAll(resp.Body)
+		fmt.Printf("Unexpected response from Steam API: %s\n", testBody)
+		return ConvertedPlayerAchievements{}, errors.New("steam API returned non-JSON response")
+	}
 
 	decoder := json.NewDecoder(resp.Body)
 

--- a/routes.go
+++ b/routes.go
@@ -24,7 +24,6 @@ func (cfg *config) routesAPI() http.Handler {
 	router.Get("/player-summaries", cfg.steamAPI.HandlerGetPlayerSummaries)
 	router.Get("/friends", cfg.steamAPI.HandlerGetFriendList)
 	router.Get("/games", cfg.steamAPI.HandlerGetOwnedGames)
-	router.Get("/games/compares", cfg.steamAPI.HandlerCompareOwnedGames)
 	router.Get("/achievements", cfg.steamAPI.HandlerGetPlayerAchievements)
 	router.Get("/friends/matchGames", cfg.steamAPI.HandlerMatchedGamesRanking)
 	router.Get("/compare-achievements", cfg.steamAPI.HandlerCompareAchievements)

--- a/run.go
+++ b/run.go
@@ -56,7 +56,7 @@ func run() error {
 			},
 			FriendListCache: api.Cache[api.FriendList]{
 				Cache:     map[string]api.CachedData[api.FriendList]{},
-				RenewTime: 10 * time.Minute,
+				RenewTime: 60 * time.Minute,
 			},
 			OwnedGamesCache: api.Cache[api.OwnedGames]{
 				Cache:     map[string]api.CachedData[api.OwnedGames]{},


### PR DESCRIPTION
Backend calls have a hard-coded wait time now depending on how many friends a user has since 429 errors from Steam were happening randomly depending on how many calls were happening.

Also start adding security functionality with HttpOnly cookies for JWT tokens and refresh tokens.